### PR TITLE
Remove `React.SFC` references

### DIFF
--- a/react/Home.tsx
+++ b/react/Home.tsx
@@ -1,9 +1,9 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, FunctionComponent } from 'react'
 import { Helmet } from 'vtex.render-runtime'
 
 import MarkdownBlock from './components/MarkdownBlock'
 
-const Home: React.SFC = () => (
+const Home: FunctionComponent = () => (
   <Fragment>
     <Helmet>
       <title>Render Guide</title>

--- a/react/PageLayout.tsx
+++ b/react/PageLayout.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
 import Sidebar from './components/Sidebar'
 
 // This component generates the base layout for this app.
-const PageLayout: React.SFC = ({ children }) => (
+const PageLayout: FunctionComponent = ({ children }) => (
   <div className="vh-100 flex flex-row">
     <Sidebar />
     <div className="w-100 overflow-y-scroll">

--- a/react/Topic.tsx
+++ b/react/Topic.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, FunctionComponent } from 'react'
 import { Helmet } from 'vtex.render-runtime'
 
 import ErrorPage from './components/ErrorPage'
@@ -6,12 +6,12 @@ import topics from './components/topics'
 
 interface Props {
   params: {
-    id?: string
-    topic: string
+    id?: string;
+    topic: string;
   }
 }
 
-const Topic: React.SFC<Props> = ({ params }) => {
+const Topic: FunctionComponent<Props> = ({ params }) => {
   const topic = topics.find(entry => entry.slug === params.topic)
 
   return topic ? (

--- a/react/components/BooksTable/index.tsx
+++ b/react/components/BooksTable/index.tsx
@@ -1,7 +1,7 @@
 // This component queries a list from the database, then it renders a table
 // with each row having a link to a details page
 
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 // withRuntimeContext provides us with the navigate function,
 // necessary for creating links
 import { RenderContextProps, withRuntimeContext } from 'vtex.render-runtime'
@@ -23,7 +23,7 @@ interface CustomProps {
 
 type Props = CustomProps & RenderContextProps
 
-const BooksTable: React.SFC<Props> = ({
+const BooksTable: FunctionComponent<Props> = ({
   isLoading,
   items,
   runtime,

--- a/react/components/ComingSoon.tsx
+++ b/react/components/ComingSoon.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { EmptyState } from 'vtex.styleguide'
 
 interface Props {
@@ -6,7 +6,7 @@ interface Props {
 }
 
 // A simple empty state with a "coming soon" message.
-const ComingSoon: React.SFC<Props> = ({ title }) => (
+const ComingSoon: FunctionComponent<Props> = ({ title }) => (
   <EmptyState title={title}>Coming soon...</EmptyState>
 )
 

--- a/react/components/ErrorPage.tsx
+++ b/react/components/ErrorPage.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
-const ErrorPage: React.SFC = () => <h1>404</h1>
+const ErrorPage: FunctionComponent = () => <h1>404</h1>
 
 export default ErrorPage

--- a/react/components/Header.tsx
+++ b/react/components/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
-const Header: React.SFC = () => <h1 className="pl5">Render Guide</h1>
+const Header: FunctionComponent = () => <h1 className="pl5">Render Guide</h1>
 
 export default Header

--- a/react/components/Input.tsx
+++ b/react/components/Input.tsx
@@ -3,7 +3,7 @@
 // available, but it's in loading state, the input will be
 // initialized, but disabled
 
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { Input as StyleguideInput, Spinner } from 'vtex.styleguide'
 
 interface Props {
@@ -15,7 +15,7 @@ interface Props {
   disabled?: boolean
 }
 
-const Input: React.SFC<Props> = ({
+const Input: FunctionComponent<Props> = ({
   autoFocus,
   loading,
   label,

--- a/react/components/MarkdownBlock/BlockQuote.tsx
+++ b/react/components/MarkdownBlock/BlockQuote.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
-const BlockQuote: React.SFC = ({ children }) => (
+const BlockQuote: FunctionComponent = ({ children }) => (
   <blockquote>
     <p>{children}</p>
   </blockquote>

--- a/react/components/MarkdownBlock/CodeBlock.tsx
+++ b/react/components/MarkdownBlock/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import highlightJs from 'highlight.js'
-import React from 'react'
+import React, { createRef, PureComponent } from 'react'
 
 // import '../code-block.global.css'
 
@@ -7,8 +7,8 @@ interface Props {
   value: string
 }
 
-class CodeBlock extends React.PureComponent<Props> {
-  private codeBlock = React.createRef<HTMLElement>()
+class CodeBlock extends PureComponent<Props> {
+  private codeBlock = createRef<HTMLElement>()
 
   constructor(props: Props) {
     super(props)

--- a/react/components/MarkdownBlock/index.tsx
+++ b/react/components/MarkdownBlock/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { Query } from 'react-apollo'
 import Markdown from 'react-markdown'
 import { Spinner } from 'vtex.styleguide'
@@ -14,7 +14,7 @@ interface Props {
 }
 
 // This component renders a markdown block synchronously.
-const MarkdownBlock: React.SFC<Props> = ({ source }) => (
+const MarkdownBlock: FunctionComponent<Props> = ({ source }) => (
   <Query query={markdownQuery} variables={{ id: source }}>
     {({ data: { source: markdownSource }, loading }) =>
       loading ? (

--- a/react/components/Pagination/PaginatedList.tsx
+++ b/react/components/Pagination/PaginatedList.tsx
@@ -5,7 +5,7 @@
 // it thinks it's necessary. To understand more about fetchMore,
 // please refer to the Apollo Docs!
 
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { Query } from 'react-apollo'
 
 import listBooks from '../../graphql/books.graphql'
@@ -20,7 +20,7 @@ interface Props {
   topicPage: string
 }
 
-const PaginatedList: React.SFC<Props> = ({ newPage, topicPage }) => (
+const PaginatedList: FunctionComponent<Props> = ({ newPage, topicPage }) => (
   <SyncQueryData prop="total" query={totalElements}>
     {({ data: { total } }) => (
       <Query query={listBooks} notifyOnNetworkStatusChange>

--- a/react/components/Pagination/TableWrapper.tsx
+++ b/react/components/Pagination/TableWrapper.tsx
@@ -1,5 +1,5 @@
 // This component is just a wrapper for Styleguide's table
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { RenderContextProps, withRuntimeContext } from 'vtex.render-runtime'
 import { Table } from 'vtex.styleguide'
 
@@ -23,7 +23,7 @@ interface CustomProps {
 
 type Props = CustomProps & RenderContextProps
 
-const TableWrapper: React.SFC<Props> = ({
+const TableWrapper: FunctionComponent<Props> = ({
   books,
   elementsPerPage,
   from,

--- a/react/components/Pagination/index.tsx
+++ b/react/components/Pagination/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
 import booksQuery from '../../graphql/books.graphql'
 import { Book } from '../../typings/custom'
@@ -14,7 +14,12 @@ interface Props {
   type: 'dynamic' | 'static'
 }
 
-const Pagination: React.SFC<Props> = ({ hasDelete, id, newPage, type }) => {
+const Pagination: FunctionComponent<Props> = ({
+  hasDelete,
+  id,
+  newPage,
+  type,
+}) => {
   const topicPage = `${type}-pagination`
 
   return (

--- a/react/components/Sidebar/Item.tsx
+++ b/react/components/Sidebar/Item.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { RenderContextProps, withRuntimeContext } from 'vtex.render-runtime'
 
 import { Topic } from '../../typings/custom'
@@ -8,7 +8,7 @@ interface Props extends RenderContextProps {
   slug?: Topic['slug']
 }
 
-const Item: React.SFC<Props> = ({ name, runtime, slug }) => {
+const Item: FunctionComponent<Props> = ({ name, runtime, slug }) => {
   const isHome = !slug
 
   return (

--- a/react/components/Sidebar/index.tsx
+++ b/react/components/Sidebar/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
 import topics from '../topics'
 
 import SidebarItem from './Item'
 
-const Sidebar: React.SFC = () => (
+const Sidebar: FunctionComponent = () => (
   <nav className="pv8 br b--light-gray">
     <ul className="pl0 list">
       <SidebarItem name="Render Guide" />

--- a/react/components/SyncQueryData.tsx
+++ b/react/components/SyncQueryData.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { Query } from 'react-apollo'
 
 interface Props {
@@ -12,7 +12,7 @@ interface Props {
 // This is a helper component that makes the query and waits untill
 // all of the data is loaded to render the children. While the data
 // is not loaded yet, a Spinner is shown.
-const SyncQueryData = ({
+const SyncQueryData: FunctionComponent<Props> = ({
   children,
   notifyOnNetworkStatusChange,
   prop,


### PR DESCRIPTION
`React.SFC` is deprecated in favor of `React.FunctionComponent`.